### PR TITLE
Add untrusted global libraries management (JENKINS-73877)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ With this plugin, you can configure a specific version of a [Shared Library](htt
 ## Setup
 
 - Be sure you have [Pipeline Groovy Libraries](https://plugins.jenkins.io/pipeline-groovy-lib/) installed
-- Go to the configuration page of your AbstractFolder
+- Go to the configuration page of your Folder, Organization Folder, Pipeline Multibranches, ...
 - Under The *Shared Library Version Override* section, add a new *Custom Configuration* element
 
 ![Configuration](doc/assets/configuration.png)
+
+## Security
+
+- A *Global Pipeline Library* without the "Allow default version to be overridden" option, can't be overridden with this plugin, a custom configuration will be skipped.
+- An overridden *Global Trusted Pipeline Library* will still be trusted.  
+- An overridden *Global Untrusted Pipeline Library* or a *Pipeline Library* defined at Folder level, will still be untrusted so their code runs with sandbox restrictions and cannot use @Grab.  
 
 ## LICENSE
 

--- a/src/main/java/io/jenkins/plugins/shared_library_version_override/LibraryCustomConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/shared_library_version_override/LibraryCustomConfiguration.java
@@ -90,7 +90,7 @@ public class LibraryCustomConfiguration extends AbstractDescribableImpl<LibraryC
 
             Set<String> libNames = new TreeSet<>();
             ItemGroup<?> group = getItemGroupFromItem(item);
-            Collection<LibraryConfiguration> libs = FolderConfigurations.getDefinedLibrariesForGroup(group);
+            Collection<LibraryConfiguration> libs = FolderConfigurations.getAllLibrariesForGroup(group);
             for (LibraryConfiguration lib : libs) {
                 libNames.add(lib.getName());
             }
@@ -116,7 +116,7 @@ public class LibraryCustomConfiguration extends AbstractDescribableImpl<LibraryC
             List<FormValidation> validations = new ArrayList<>();
             // Check name existence and version override allowance
             ItemGroup<?> group = getItemGroupFromItem(item);
-            Collection<LibraryConfiguration> libs = FolderConfigurations.getDefinedLibrariesForGroup(group);
+            Collection<LibraryConfiguration> libs = FolderConfigurations.getAllLibrariesForGroup(group);
             LibraryConfiguration lib = libs.stream()
                     .filter(l -> l.getName().equals(name))
                     .findFirst()


### PR DESCRIPTION
This feature have for purpose to manage Untrusted Global Librairies which are, till now, ignored.
This was suggested by @daniel-beck in [SECURITY-3466](https://issues.jenkins.io/browse/SECURITY-3466).

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
